### PR TITLE
WS-724: Fix problems preventing maven from parsing pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
   <build>
     <sourceDirectory>src/</sourceDirectory>
     <outputDirectory>classes/</outputDirectory>
+    <finalName>laptops</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -47,7 +48,7 @@
     <url>https://maven.oracle.com</url>
     <layout>default</layout>
   </repository>
-  repository>
+  <repository>
       <id>http://mvnrepository.com/</id>
       <url>http://mvnrepository.com</url>
     </repository>
@@ -154,7 +155,4 @@
     <artifactId>Application1</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-  <build>
-    <finalName>laptops</finalName>
-  </build>
 </project>


### PR DESCRIPTION
This fixes two problems which prevent maven from parsing pom.xml - it exits with errors before it can try to build.

One is malformed XML on a `<repository>` tag.

The other involves a second set of `<build></build>` tags.  Per http://maven.apache.org/pom.html#Build it appears that if there are multiple sets of these, the additional ones need to be within `profile` sections, which we don't currently have.  I fixed this by moving the contents of the second `build` to be within the first, then deleted the second.
