### PR TITLE
WS-724: Exclude maven build artifacts from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 ### Java in general ###
 *.class
 
+### Maven ###
+target/
+# Maven downloads project dependencies here
+# Is this better than .gitignore-ing all *.jar?
+public_html/WEB-INF/lib/
+
 ### JDeveloper-specific ###
 # default output directories
 classes/


### PR DESCRIPTION
https://www.gitignore.io/api/maven,java,jdeveloper suggests excluding all _.jar, and doesn't mention `public_html/WEB-INF/lib/` (which now contains many *.jar files).  Are there resources which could go in `public_html/WEB-INF/lib/` which *should_ be stored in the git repo?

Reject if you think it's better to ignore *.jar instead of this directory.
